### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/ffmpeg_api.py
+++ b/ffmpeg_api.py
@@ -62,7 +62,10 @@ async def download_file(filename: str, background_tasks: BackgroundTasks):
     """
     Download the converted MP3 file. The file is deleted after 24 hours.
     """
-    file_path = f"{UPLOAD_FOLDER}/{filename}"
+    file_path = os.path.normpath(os.path.join(UPLOAD_FOLDER, filename))
+
+    if not file_path.startswith(UPLOAD_FOLDER):
+        return {"error": "Invalid file path"}
 
     if not os.path.exists(file_path):
         return {"error": "File not found"}


### PR DESCRIPTION
Potential fix for [https://github.com/johnnyfleet/ffmpeg-mp4-to-mp3-api/security/code-scanning/3](https://github.com/johnnyfleet/ffmpeg-mp4-to-mp3-api/security/code-scanning/3)

To fix the problem, we need to ensure that the constructed `file_path` is contained within the `UPLOAD_FOLDER` directory. This can be achieved by normalizing the path and verifying that it starts with the `UPLOAD_FOLDER` path. This approach will prevent path traversal attacks by ensuring that the `file_path` does not escape the intended directory.

1. Normalize the `file_path` using `os.path.normpath`.
2. Check that the normalized `file_path` starts with the `UPLOAD_FOLDER` path.
3. Raise an exception or return an error if the check fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
